### PR TITLE
Handle null MIME type

### DIFF
--- a/src/HarRequestImporter.js
+++ b/src/HarRequestImporter.js
@@ -121,7 +121,9 @@ class HarRequestImporter {
 
     const { text, mimeType, params } = postData
 
-    if ('string' === typeof text) {
+    if (mimeType == null) {
+      pawRequest.body = text
+    } else if ('string' === typeof text) {
       if (mimeType.startsWith('application/json')) {
         try {
           pawRequest.jsonBody = JSON.parse(text)
@@ -213,7 +215,12 @@ class HarRequestImporter {
         if ('string' === typeof text) {
           let decodedString = text
           if (encoding === 'base64') {
-            decodedString = utf8.decode(base64.decode(text))
+            try {
+              decodedString = utf8.decode(base64.decode(text))
+            } catch (e) {
+              decodedString = "Unable to decode body."
+            }
+
           }
           description += '\n'
           description += '### Body\n\n'


### PR DESCRIPTION
Ideally, there is always a mimetype provided when attempting to import a HAR file.
However in practice when importing HAR files from proxy sources (such as Charles),
you may receive requests with no MIME type. Currently this fails the import for
the entire HAR.

This change will cause HAR imports to succeed even when a HAR has a request with
a missing MIME type. I decided to use this behavior because it roughly mimics what
Mozilla does.

https://developer.mozilla.org/en-US/docs/Mozilla/How_Mozilla_determines_MIME_Types#Unknown_Decoder

Fixes #7
Fixes #6